### PR TITLE
Change silero module minSdkVersion from 23 to 21

### DIFF
--- a/silero/build.gradle
+++ b/silero/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion 33
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 9
         versionName "2.0.3"


### PR DESCRIPTION
I found that the minimum supported version of the current onnx module（`com.microsoft.onnxruntime:onnxruntime-android:1.15.1`） is **21**, so the **silero** module theoretically does not need to be set to **23**, and no higher API is used.


<img width="914" alt="image" src="https://github.com/gkonovalov/android-vad/assets/6247142/243160bd-fe30-4cfe-b32f-f2355ee2ef78">
